### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,6 +5,11 @@ jobs:
   gradle:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,11 +5,6 @@ jobs:
   gradle:
     name: Build and Test
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -20,9 +15,3 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: build
-      - name: Test Report
-        uses: scacap/action-surefire-report@v1
-        if: always()
-        with:
-          report_paths: "build/test-results/test/TEST-*.xml"
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/test/kotlin/AppTest.kt
+++ b/src/test/kotlin/AppTest.kt
@@ -5,7 +5,7 @@ import com.google.firebase.FirebasePlatform
 import com.google.firebase.initialize
 import org.junit.Test
 
-class AppTest {
+class AppTest : FirebaseTest() {
     @Test
     fun testInitialize() {
         FirebasePlatform.initializeFirebasePlatform(object : FirebasePlatform() {

--- a/src/test/kotlin/FirebaseTest.kt
+++ b/src/test/kotlin/FirebaseTest.kt
@@ -1,0 +1,9 @@
+import com.google.firebase.FirebaseApp
+import org.junit.Before
+
+abstract class FirebaseTest {
+    @Before
+    fun beforeEach() {
+        FirebaseApp.clearInstancesForTest()
+    }
+}

--- a/src/test/kotlin/FirestoreTest.kt
+++ b/src/test/kotlin/FirestoreTest.kt
@@ -11,7 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 
-class FirestoreTest {
+class FirestoreTest : FirebaseTest() {
     @Before
     fun initialize() {
         FirebasePlatform.initializeFirebasePlatform(object : FirebasePlatform() {


### PR DESCRIPTION
PR tests were previously failing because there are currently two tests that both initialize the default Firebase app.

I originally wanted to just use different instance per each test, but FirebaseApp internals always expect that default app exist, so I added a simple cleanup before each test instead.