### PR TITLE
Lifecycle dependency upgrade 2.8.0-rc01

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,6 +155,7 @@ dependencies {
     aar("com.google.firebase:firebase-config:21.6.0")
     aar("com.google.firebase:firebase-installations:17.2.0")
     // extracted aar dependencies
+    // exclude lifecycle libs due to https://github.com/GitLiveApp/firebase-java-sdk/pull/15 - remove the exclude  once the dependencies in the aars are updated to the required version
     api(fileTree(mapOf("dir" to "build/jar", "include" to listOf("*.jar"), "exclude" to listOf("lifecycle-*"))))
     // polyfill dependencies
     implementation("org.jetbrains.kotlin:kotlin-stdlib")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,7 +155,7 @@ dependencies {
     aar("com.google.firebase:firebase-config:21.6.0")
     aar("com.google.firebase:firebase-installations:17.2.0")
     // extracted aar dependencies
-    api(fileTree(mapOf("dir" to "build/jar", "include" to listOf("*.jar"))))
+    api(fileTree(mapOf("dir" to "build/jar", "include" to listOf("*.jar"), "exclude" to listOf("lifecycle-*"))))
     // polyfill dependencies
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
@@ -165,12 +165,12 @@ dependencies {
     // firebase dependencies
     implementation("javax.inject:javax.inject:1")
     implementation("com.squareup.okhttp3:okhttp:3.12.13")
-    implementation("android.arch.lifecycle:common:1.1.1")
     implementation("io.grpc:grpc-protobuf-lite:1.52.1")
     implementation("io.grpc:grpc-stub:1.52.1")
     implementation("androidx.collection:collection:1.2.0")
-    implementation("androidx.lifecycle:lifecycle-common:2.4.0")
     implementation("io.grpc:grpc-okhttp:1.52.1")
+    implementation("androidx.lifecycle:lifecycle-common:2.8.0-rc01")
+    implementation("androidx.lifecycle:lifecycle-viewmodel:2.8.0-rc01")
 }
 
 tasks.named("publishToMavenLocal").configure {


### PR DESCRIPTION
## Issue
Use `firebase-java-sdk 0.4.2` with `Compose Multiplatform 1.6.10-rc01` get crash.
- Android Lifecycle dependency version issue.
- remove old dependency (android.arch)
- upgrade Lifecycle dependency to 2.8.0-rc01

```
Exception in thread "main" java.lang.NoSuchMethodError: 'void androidx.lifecycle.LifecycleRegistry.setCurrentState(androidx.lifecycle.Lifecycle$State)'
	at androidx.compose.ui.scene.ComposeContainer.updateLifecycleState(ComposeContainer.desktop.kt:436)
	at androidx.compose.ui.scene.ComposeContainer.onChangeWindowFocus(ComposeContainer.desktop.kt:216)
	at androidx.compose.ui.scene.ComposeContainer.setWindow(ComposeContainer.desktop.kt:297)
	at androidx.compose.ui.scene.ComposeContainer.<init>(ComposeContainer.desktop.kt:164)
	at androidx.compose.ui.scene.ComposeContainer.<init>(ComposeContainer.desktop.kt:82)
	at androidx.compose.ui.awt.ComposeWindowPanel.<init>(ComposeWindowPanel.desktop.kt:56)
	at androidx.compose.ui.awt.ComposeWindow.<init>(ComposeWindow.desktop.kt:65)
	at androidx.compose.ui.awt.ComposeWindow.<init>(ComposeWindow.desktop.kt:63)
	at androidx.compose.ui.window.Window_desktopKt$Window$3.invoke(Window.desktop.kt:182)
	at androidx.compose.ui.window.Window_desktopKt$Window$3.invoke(Window.desktop.kt:176)
	at androidx.compose.ui.window.Window_desktopKt$Window$10.invoke(Window.desktop.kt:409)
	at androidx.compose.ui.window.Window_desktopKt$Window$10.invoke(Window.desktop.kt:406)
	at androidx.compose.ui.window.AwtWindow_desktopKt$AwtWindow$2.invoke(AwtWindow.desktop.kt:70)
	at androidx.compose.ui.window.AwtWindow_desktopKt$AwtWindow$2.invoke(AwtWindow.desktop.kt:69)
	at androidx.compose.runtime.DisposableEffectImpl.onRemembered(Effects.kt:82)
	at androidx.compose.runtime.CompositionImpl$RememberEventDispatcher.dispatchRememberObservers(Composition.kt:1295)
	at androidx.compose.runtime.CompositionImpl.applyChangesInLocked(Composition.kt:984)
	at androidx.compose.runtime.CompositionImpl.applyChanges(Composition.kt:1005)
	at androidx.compose.runtime.Recomposer.composeInitial$runtime(Recomposer.kt:1099)
	at androidx.compose.runtime.CompositionImpl.composeInitial(Composition.kt:633)
	at androidx.compose.runtime.CompositionImpl.setContent(Composition.kt:619)
	at androidx.compose.ui.window.Application_desktopKt$awaitApplication$2$1$2.invokeSuspend(Application.desktop.kt:221)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(Unknown Source)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(Unknown Source)
	at java.desktop/java.awt.EventQueue$3.run(Unknown Source)
	at java.desktop/java.awt.EventQueue$3.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.desktop/java.awt.EventQueue.dispatchEvent(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.desktop/java.awt.EventDispatchThread.run(Unknown Source)

```